### PR TITLE
fix: volume to local sanic-web & chat-vue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,11 @@ web/.vscode/
 logs/
 # 环境变量文件
 .pytest_cache/
+
+.DS_Store
+.pem
+docker/dify/docker/volumes/app/storage
+docker/dify/docker/volumes/db/data
+docker/dify/docker/volumes/plugin_daemon
+docker/dify/docker/volumes/weaviate
+docker/dify/docker/volumes/redis

--- a/docker/dify/docker/volumes/sandbox/conf/config.yaml
+++ b/docker/dify/docker/volumes/sandbox/conf/config.yaml
@@ -1,0 +1,14 @@
+app:
+  port: 8194
+  debug: True
+  key: dify-sandbox
+max_workers: 4
+max_requests: 50
+worker_timeout: 5
+python_path: /usr/local/bin/python3
+enable_network: True # please make sure there is no network risk in your environment
+allowed_syscalls: # please leave it empty if you have no idea how seccomp works
+proxy:
+  socks5: ''
+  http: ''
+  https: ''

--- a/docker/dify/数据问答_v1.1.2_deepseek.yml
+++ b/docker/dify/数据问答_v1.1.2_deepseek.yml
@@ -1488,7 +1488,8 @@ workflow:
             \ SELECT 产地, COUNT(*) as 商品数量 FROM excel_table GROUP BY 产地\n- 只能使用表结构信息中提供的表来生成\
             \ sql，如果无法根据提供的表结构中生成 sql ，请说：'提供的表结构信息不足以生成 sql 查询。'禁止随意捏造信息。\n- 请从如下给出的展示方式种选择最形象的一种用以进行数据渲染，将类型名称放入返回要求格式的name参数值中，如果找不到最合适的则使用'Table'作为展示方式，数据展示方式如下:\n\
             \ {{#1721978276391.nl2sql_display_type#}}\n# 返回格式:\n 请一步步思考并按照以下JSON格式回复：{{#1721978276391.nl2sql_response#}}\n\
-            \ 确保返回正确的json并且可以被Python json.loads方法解析."
+            \ 确保返回正确的json并且可以被Python json.loads方法解析.不需要 json``` 包裹，使用方会将这个数据直接用于 parse
+            \另外注意若用到了UNPIVOT， 为了使 UNPIVOT 操作能够正常工作，需要将所有列转换为同一数据类型。通常，将所有列转换为 VARCHAR 类型是一个常见的解决方案。"
         selected: false
         title: 文件问答
         type: llm

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -4,6 +4,9 @@ services:
   chat-web:
     image: apconw/chat-vue3-mvp:1.1.2
     container_name: chat-vue3-mvp
+    volumes:
+      - /Users/raku/repos/sanic-web/web/dist:/usr/share/nginx/html
+      - /Users/raku/repos/sanic-web/web/docker/nginx.conf:/etc/nginx/conf.d/default.conf    
     ports:
       - "8081:80"
     extra_hosts:
@@ -27,13 +30,15 @@ services:
   chat-service:
     image: apconw/sanic-web:1.1.2
     container_name: sanic-web
+    volumes:
+      - /Users/raku/repos/sanic-web:/sanic-web    
     environment:
       - ENV=test
       - DIFY_SERVER_URL=http://host.docker.internal:18000
-      - DIFY_DATABASE_QA_API_KEY=app-AXDUw8TtcY7N6TMGHkPaC4VF
+      - DIFY_DATABASE_QA_API_KEY=app-jRaQpLgZ8O0iXLIybj5ixoQv
       - MINIO_ENDPOINT=host.docker.internal:19000
-      - MINIO_ACCESS_KEY=sIR5eeDkiwoo779yNJbw
-      - MiNIO_SECRET_KEY=MreuQ3aC1ymHJeo3QfzSg7aPz7PqlxeOw39nZUdE
+      - MINIO_ACCESS_KEY=d3WqsZ8Cr082lvfLPdZZ
+      - MiNIO_SECRET_KEY=TZVHunZUy04KISJ9zZWcVdx1Bbso90yTtl6s43Kr
     ports:
       - "8088:8088"
     extra_hosts:

--- a/services/db_qadata_process.py
+++ b/services/db_qadata_process.py
@@ -127,20 +127,21 @@ def process(data):
             type_enum = ChartTypeEnum.TABLE_CHART
         elif type_enum == ChartTypeEnum.PIE_CHART and len(column_data) > 2:
             type_enum = ChartTypeEnum.TABLE_CHART
-        elif type_enum == ChartTypeEnum.BAR_CHART:
+        # elif type_enum == ChartTypeEnum.BAR_CHART:
+            
             # 如果大模型返回柱状图且如果包含多列中文，则使用表格展示
-            if chart_data:
-                json_object = chart_data[0]
-                if json_object is not None:
-                    count = sum(1 for key in json_object.keys() if (item := json_object.get(key)) and pattern.match(str(item)))
-                    if count > 1:
-                        type_enum = ChartTypeEnum.TABLE_CHART
+            # if chart_data:
+            #     json_object = chart_data[0]
+            #     if json_object is not None:
+            #         count = sum(1 for key in json_object.keys() if (item := json_object.get(key)) and pattern.match(str(item)))
+            #         if count > 1:
+            #             type_enum = ChartTypeEnum.TABLE_CHART
 
-            # 如果 columnData 列表中的元素数量大于3，则更改图表类型为表格
-            if len(column_data) > 3:
-                type_enum = ChartTypeEnum.TABLE_CHART
-        elif type_enum == ChartTypeEnum.LINE_CHART and len(column_data) > 2:
-            type_enum = ChartTypeEnum.TABLE_CHART
+            # # 如果 columnData 列表中的元素数量大于3，则更改图表类型为表格
+            # if len(column_data) > 3:
+            #     type_enum = ChartTypeEnum.TABLE_CHART
+        # elif type_enum == ChartTypeEnum.LINE_CHART and len(column_data) > 2:
+            # type_enum = ChartTypeEnum.TABLE_CHART
 
         handlers = {
             ChartTypeEnum.TABLE_CHART: process_table_chart,
@@ -244,10 +245,10 @@ def process_bar_chart(llm_info: Dict[str, Any], column_data: List[str], chart_da
                 first_item = chart_data[0]
                 for key in first_item.keys():
                     item_value = first_item[key]
-                    if is_numeric(item_value):
-                        column_array[k] = "数量"
-                    elif is_valid_date(item_value):
-                        column_array[k] = "日期"
+                    # if is_numeric(item_value):
+                    #     column_array[k] = "数量"
+                    # elif is_valid_date(item_value):
+                    #     column_array[k] = "日期"
 
         data_list.append(column_array)
 

--- a/services/pandas_ai_service.py
+++ b/services/pandas_ai_service.py
@@ -212,11 +212,19 @@ async def read_excel(file_url: str):
     try:
         # 分割URL以获取文件名部分
         extension = file_url.split("/")[-1].split(".")[-1].split("?")[0]
+        print(f"[DEBUG] 开始读取文件: {file_url}, 扩展名: {extension}")  # 添加文件信息日志
+        
         if extension in ["xlsx", "xls"]:
             with pd.ExcelFile(file_url) as xls:
-                sheets_data = {sheet_name: xls.parse(sheet_name).head(1) for sheet_name in xls.sheet_names}
+                print(f"[DEBUG] 找到工作表: {xls.sheet_names}")  # 添加工作表列表日志
+                sheets_data = {}
+                for sheet_name in xls.sheet_names:
+                    df = xls.parse(sheet_name).head(1)
+                    print(f"[DEBUG] 工作表 '{sheet_name}' 读取到 {len(df)} 行数据")  # 添加每表数据日志
+                    sheets_data[sheet_name] = df
         elif extension in "csv":
             xls = pd.read_csv(file_url)
+            print(f"[DEBUG] CSV文件读取到 {len(xls)} 行数据")  # 添加CSV数据日志
             sheets_data = {"sheet1": xls.head(1)}
         else:
             raise ValueError("Unsupported file extension")
@@ -224,9 +232,14 @@ async def read_excel(file_url: str):
         # 遍历每个工作表并转换为所需的列表格式
         sheets_data_list_format = {}
         for sheet_name, df in sheets_data.items():
-            sheets_data_list_format[sheet_name] = {"excel表头": df.columns.tolist(), "excel数据": df.values.tolist()}
+            print(f"[DEBUG] 处理工作表 '{sheet_name}' 数据")  # 添加数据处理日志
+            sheets_data_list_format[sheet_name] = {
+                "excel表头": df.columns.tolist(), 
+                "excel数据": df.values.tolist()
+            }
         return json.dumps(sheets_data_list_format, ensure_ascii=False, cls=DateEncoder)
     except Exception as e:
+        print(f"[ERROR] 读取文件失败: {str(e)}")  # 增强错误日志
         traceback.print_exception(e)
 
 
@@ -255,6 +268,7 @@ async def read_file_columns(file_url: str):
 
         # 获取列名称并转换为列表
         columns = df.columns.tolist()
+        
 
         # 将列名称转为JSON格式返回
         return json.dumps(columns, ensure_ascii=False)

--- a/services/ta_assistant_service.py
+++ b/services/ta_assistant_service.py
@@ -356,6 +356,7 @@ def build_prompt(doc_content) -> str:
     # 返回格式
     请一步步思考并按照以下JSON格式回复：{result_format}
     确保返回正确的json并且可以被Python json.loads方法解析.
+    不需要 json``` 包裹，使用方会将这个数据直接用于 parse
     """
     return prompt_content
 

--- a/services/text2_sql_service.py
+++ b/services/text2_sql_service.py
@@ -72,17 +72,8 @@ if __name__ == "__main__":
 async def exe_file_sql_query(file_key, model_out_str):
     """
     文件问答: 执行大模型解析出的SQL语句并返回结果集
-
-    Args:
-        file_key (str): 文件key
-        model_out_str (str): 大模型输出信息
-
-    Returns:
-        dict: {"column":[], "result":[]}
-
-    Raises:
-        MyException: 当文件问答大模型返回结果为空或SQL语句为空时抛出异常
     """
+    print("model out str", file_key, model_out_str)
     if not model_out_str:
         logger.error("文件问答大模型返回结果为空")
         raise MyException(SysCode.c_9999)
@@ -108,8 +99,9 @@ async def exe_file_sql_query(file_key, model_out_str):
 
         # 解析模型输出并获取SQL语句
         model_out_json = json.loads(model_out_str)
-        sql = model_out_json.get("sql", "").replace("`", "")  # 移除反引号以避免SQL语法错误
-
+        sql = model_out_json.get("sql", "")
+        logger.info(f"即将执行的SQL语句: {sql}")  # 添加SQL日志输出
+        
         if not sql.strip():
             logger.error("文件问答大模型返回SQL语句为空")
             raise MyException(SysCode.c_9999)

--- a/web/package.json
+++ b/web/package.json
@@ -98,5 +98,6 @@
     "vite": "^5.2.12",
     "vite-raw-plugin": "^1.0.2",
     "vue-eslint-parser": "^9.4.3"
-  }
+  },
+  "packageManager": "pnpm@10.9.0+sha512.0486e394640d3c1fb3c9d43d49cf92879ff74f8516959c235308f5a8f62e2e19528a65cdc2a3058f587cde71eba3d5b56327c8c33a97e4c4051ca48a10ca2d5f"
 }

--- a/web/src/components/MarkdownPreview/MarkdownEcharts.vue
+++ b/web/src/components/MarkdownPreview/MarkdownEcharts.vue
@@ -94,7 +94,7 @@ onMounted(() => {
         // 遍历数据
         data.forEach((item) => {
             const product = item[0]
-            const cases = parseInt(item[1], 10)
+            const cases = parseInt(item[item.length -1], 10)
 
             // 只当转换为数字成功时才添加到数组中
             if (!isNaN(cases)) {


### PR DESCRIPTION
## Summary by Sourcery

Enable local development hot-reloading via Docker volume mounts and add extensive debugging logs. Includes fixes for chart data processing and SQL query generation.

Bug Fixes:
- Correctly parse numerical data from the last column for Echarts rendering.
- Remove logic that incorrectly defaulted certain charts (Bar, Line) to Table view.
- Preserve backticks in LLM-generated SQL queries.
- Prevent automatic renaming of columns based on detected data types in bar charts.
- Prevent automatic conversion of multi-column Pie, Bar, and Line charts to Table charts.
- Update prompt for text-to-SQL service to prevent JSON wrapping errors.
- Fix incorrect parsing of numerical data for Echarts rendering in Markdown previews

Enhancements:
- Add extensive debug logging to file reading, API request handling, and SQL execution services.

Build:
- Add volume mounts to `docker-compose.yaml` for `chat-web` and `chat-service` to enable local development.
- Specify `pnpm` package manager in `web/package.json`.
- Add sandbox configuration file for Dify.
- Update Dify workflow configuration file (`数据问答_v1.1.2_deepseek.yml`).